### PR TITLE
feat(tags): add support for tags to enable alternate encoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,32 @@ This library provides a way to template JSON using paths extracted from another 
 So we have an event come through, we extract a few fields and insert them into another JSON document.
 
 ```go
-var template = `{
-  "name": ${msg.name},
-  "age": ${msg.age},
-  "cyclist": ${msg.cyclist}
-}`
-
 func ExampleTemplate_ExecuteToString() {
 
-	tpl, _ := jsontemplate.NewTemplate(template)
+	tpl, _ := jsontemplate.NewTemplate(`{"name": ${msg.name},"age": ${msg.age},"cyclist": ${msg.cyclist}}`)
 
 	res, _ := tpl.ExecuteToString([]byte(`{"msg":{"name":"markw","age":23,"cyclist":true}}`))
 	fmt.Println(res)
 	// Output:
-	// {
-	//   "name": "markw",
-	//   "age": 23,
-	//   "cyclist": true
-	// }
+	// {"name": "markw","age": 23,"cyclist": true}
+}
+```
+
+## tags
+
+To customise how the JSON is rendered, you can use tags which are provided after the path and delimited by `;`:
+
+* `escape`, this will escape the JSON output.
+
+```go
+func ExampleTemplate_ExecuteToString_encoded() {
+
+	tpl, _ := jsontemplate.NewTemplate(`{"msg": ${msg;escape}`)
+
+	res, _ := tpl.ExecuteToString([]byte(`{"msg":{"name":"markw","age":23,"cyclist":true}}`))
+	fmt.Println(res)
+	// Output:
+	// {"msg": "{\"name\":\"markw\",\"age\":23,\"cyclist\":true}"
 }
 ```
 
@@ -37,9 +45,10 @@ go test -bench=. -benchmem
 goos: darwin
 goarch: arm64
 pkg: github.com/wolfeidau/jsontemplate
-BenchmarkTemplate_ExecuteToString-10    	  606963	      2087 ns/op	    4695 B/op	     131 allocs/op
+BenchmarkTemplate_ExecuteToString-10    	  559975	      2188 ns/op	    4767 B/op	     134 allocs/op
+BenchmarkTemplate_Execute-10            	  523843	      2282 ns/op	    4876 B/op	     136 allocs/op
 PASS
-ok  	github.com/wolfeidau/jsontemplate	1.402s
+ok  	github.com/wolfeidau/jsontemplate	3.893s
 ```
 
 # License

--- a/example_test.go
+++ b/example_test.go
@@ -6,22 +6,22 @@ import (
 	"github.com/wolfeidau/jsontemplate"
 )
 
-var template = `{
-  "name": ${msg.name},
-  "age": ${msg.age},
-  "cyclist": ${msg.cyclist}
-}`
-
 func ExampleTemplate_ExecuteToString() {
 
-	tpl, _ := jsontemplate.NewTemplate(template)
+	tpl, _ := jsontemplate.NewTemplate(`{"name": ${msg.name},"age": ${msg.age},"cyclist": ${msg.cyclist}}`)
 
 	res, _ := tpl.ExecuteToString([]byte(`{"msg":{"name":"markw","age":23,"cyclist":true}}`))
 	fmt.Println(res)
 	// Output:
-	// {
-	//   "name": "markw",
-	//   "age": 23,
-	//   "cyclist": true
-	// }
+	// {"name": "markw","age": 23,"cyclist": true}
+}
+
+func ExampleTemplate_ExecuteToString_encoded() {
+
+	tpl, _ := jsontemplate.NewTemplate(`{"msg": ${msg;escape}`)
+
+	res, _ := tpl.ExecuteToString([]byte(`{"msg":{"name":"markw","age":23,"cyclist":true}}`))
+	fmt.Println(res)
+	// Output:
+	// {"msg": "{\"name\":\"markw\",\"age\":23,\"cyclist\":true}"
 }

--- a/json_test.go
+++ b/json_test.go
@@ -116,3 +116,28 @@ func BenchmarkTemplate_ExecuteToString(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkTemplate_Execute(b *testing.B) {
+
+	content := []byte(`{"msg":{"name":"markw","age":23,"cyclist":true}}`)
+	expectedResult := `{"data":"markw",count:23,"flag":true}`
+
+	tpl, err := NewTemplate(`{"data":${msg.name},count:${msg.age},"flag":${msg.cyclist}}`)
+	if err != nil {
+		b.Fatalf("error in template: %s", err)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := new(bytes.Buffer)
+			_, err := tpl.Execute(buf, content)
+			if err != nil {
+				b.Fatalf("unexpected error: %s", err)
+			}
+			if buf.String() != expectedResult {
+				b.Fatalf("unexpected result\n%q\nExpected\n%q\n", buf.String(), expectedResult)
+			}
+		}
+	})
+}

--- a/path_test.go
+++ b/path_test.go
@@ -84,6 +84,18 @@ func TestDocument_Read(t *testing.T) {
 			content:    []byte(`{"data":{"names":["a","b","c"]}}`),
 			wantResult: "a",
 		},
+		{
+			name:       "should extract string field from document",
+			args:       args{path: "data;escape"},
+			content:    []byte(`{"data":{"names":["a","b","c"]}}`),
+			wantResult: `{"names":["a","b","c"]}`,
+		},
+		{
+			name:    "should extract string field from document",
+			args:    args{path: "data;nope"},
+			content: []byte(`{"data":{"names":["a","b","c"]}}`),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This adds support for encoding options, these can change the way the json encoder serialises the results of a path match.
